### PR TITLE
Migrate support email to support@ditto.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The "Online With Authentication" identity type is geared towards apps that will 
 
 [For more information, read the documentation](https://docs.ditto.live/ios/common/security/authentication)
 
-For support, please contact Ditto Support (support@ditto.live).
+For support, please contact Ditto Support (support@ditto.com).
 
 ## Try it on repl.it
 

--- a/iOS/iOS-auth0/README.md
+++ b/iOS/iOS-auth0/README.md
@@ -16,4 +16,4 @@
 
 ## Access Token
 
-Contact us at [support@ditto.live](support@ditto.live) to request a free license token!
+Contact us at [support@ditto.com](mailto:support@ditto.com) to request a free license token!


### PR DESCRIPTION
## Summary
- Updates README support contact (root and `iOS/iOS-auth0/`) from `support@ditto.live` to `support@ditto.com`.
- Fixes malformed mailto link in `iOS/iOS-auth0/README.md` (now uses `mailto:` prefix).